### PR TITLE
Added support for inline templates, and for routes w/o templates

### DIFF
--- a/src/navigate.js
+++ b/src/navigate.js
@@ -51,7 +51,7 @@ function($rootScope, $location, $route) {
   }
   $rootScope.$on('$routeChangeSuccess', function($event, next, last) {
     // Only navigate if it's a valid route and it's not gonna just redirect immediately
-    if (next.$route && !next.$route.redirectTo) { 
+    if (!next.$route || !next.$route.redirectTo) {
       (self.onRouteSuccess || defaultRouteSuccess)($event, next, last);
     }
   });
@@ -71,7 +71,7 @@ function($rootScope, $location, $route) {
     //Wait for successful route change before actually doing stuff
     self.onRouteSuccess = function($event, next, last) {
       self.current && navHistory.push(self.current);
-      self.next = new Page(path, transition || next.$route.transition, isReverse);
+      self.next = new Page(path, transition || (next.$route && next.$route.transition), isReverse);
       navigate(self.next, self.current, false);
     };
   };

--- a/src/view.js
+++ b/src/view.js
@@ -17,7 +17,10 @@ function($rootScope, $compile, $controller, $route, $change) {
         page.element.contents().data('$ngControllerController', page.controller);
       }
       $compile(page.element.contents())(page.scope);
-      viewElement.append(page.element);
+      if (locals && locals.$template) {
+        // only append page element if a template exists
+        viewElement.append(page.element);
+      }
       page.scope.$emit('$viewContentLoaded');
       page.scope.$eval(attrs.onLoad);
     }

--- a/src/view.js
+++ b/src/view.js
@@ -28,7 +28,7 @@ function($rootScope, $compile, $controller, $route, $change) {
         insertPage(dest);
         var transition = reverse ? source.transition() : dest.transition();
         //If the page is marked as reverse, reverse the direction (lol)
-        if (dest.reverse() || ($route.current && $route.current.$route.reverse)) {
+        if (dest.reverse() || ($route.current && $route.current.$route && $route.current.$route.reverse)) {
           reverse = !reverse;
         }
         var promise = $change(dest.element, (source ? source.element : null),


### PR DESCRIPTION
These two features/fixes are in separate commits.

By inline templates I mean things like:

``` javascript
$routeProvider.when('/inTheDistance', {
  template: '<div>A flock of moose!</div>',
  controller: 'myCtrl'
});
```

And routes without templates are cool because then you can have some kind of persistent DOM on top of which you pull in your other views. Something like this:

``` javascript
$routeProvider
  .when('/settings', {
    templateUrl: 'myLovelySettings.html',
    controller: 'settingsCtrl'
  }
  .otherwise({
    template: null
  });
```

My use case is a google map view that's on my main screen, which I don't want to reinitialize every time I return from another view. There might be better ways to do this too. Let me know if you have any suggestions!
