### PR TITLE
fix(view.js) undefined routes lead to an error while .reverse lookup

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -31,7 +31,7 @@ function($rootScope, $compile, $controller, $route, $change, $q) {
     var currentTrans;
     scope.$on('$pageTransitionStart', function ($event, dest, source, reverse) {
       function changePage() {
-        var current = $route.current ? $route.current.$$route : {};
+        var current = $route.current.$$route ? $route.current.$$route : {};
         var transition = reverse ? source.transition() : dest.transition();
 
         insertPage(dest);
@@ -98,7 +98,7 @@ function($rootScope, $compile, $controller, $route, $change, $q) {
   return {
     restrict: 'EA',
     link: function(scope, elm, attrs) {
-      var route = $route.current ? $route.current.$$route : {};
+      var route = $route.current.$$route ? $route.current.$$route : {};
       var template = route.templateUrl || route.template;
       var rawElm = elm[0];
 


### PR DESCRIPTION
If an app has an undefined route, which may occur in dynamic environments, the route was not set properly, because $route.current was defined, while $route.current.$$route was undefined.
