### PR TITLE
Update navigate.js

### DIFF
--- a/src/navigate.js
+++ b/src/navigate.js
@@ -45,7 +45,6 @@ angular.module('ajoslin.mobile-navigate')
     nav.onRouteSuccess = null;
     //Add a default onroutesuccess for the very first page
     function defaultRouteSuccess($event, next, last) {
-      nav.current && navHistory.push(nav.current);
       nav.next = new Page($location.path());
       nav.next.transitionOnce('none');
       navigate(nav.next);


### PR DESCRIPTION
The very first page should not be added to the history because this causes navHistory.length to be 1 and asides from inconsistencies with nav.eraseHistory => 0 this leads to nav.back always returning true which prevents Android back button from working correctly.
