### PR TITLE
Included Event to be fired when mobile-nav has changed a page

### DIFF
--- a/src/change.js
+++ b/src/change.js
@@ -106,6 +106,7 @@ angular.module('ajoslin.mobile-navigate')
         boundElement && boundElement.unbind(ANIMATION_END, done);
         next.removeClass(nextClasses);
         prev && prev.removeClass(prevClasses);
+        $rootScope.$broadcast("mobile-nav-page-changed");
       });
 
       //Let the user of change 'cancel' to finish transition early if they wish


### PR DESCRIPTION
This event is useful if you want to start a action (like animations) when the page has been successfully displayed and the animation is finished.
