### PR TITLE
feat(navigate.go) query parameters support

### DIFF
--- a/src/navigate.js
+++ b/src/navigate.js
@@ -61,15 +61,25 @@ angular.module('ajoslin.mobile-navigate')
     /*
      * go -transitions to new page
      * @param path - new path
+     * @param {optional} object uri query parameters
      * @param {optional} String transition
      * @param {optional} boolean isReverse, default false
      */
-    nav.go = function go(path, transition, isReverse) {
+    nav.go = function go(path, params, transition, isReverse) {
+      var _$location = $location;
+      if (angular.isObject(params)) {
+        _$location = $location.search(params);
+      }
+      else { 
+        isReverse = transition;
+        transition = params;
+        params = undefined;
+      }
       if (typeof transition == 'boolean') {
         isReverse = transition;
         transition = null;
       }
-      $location.path(path);
+      _$location.path(path);
       //Wait for successful route change before actually doing stuff
       nav.onRouteSuccess = function($event, next, last) {
         nav.current && navHistory.push(nav.current);


### PR DESCRIPTION
I added support for query parameters, e.g.
$navigate.go('/my/path', {name : 'john dow'});

results in #/my/path?name=john%20down

transistion and isReverse still work, the new paraeter is optional.

interface of go() method is compatible with older versions, existing apps do not have to be updated
